### PR TITLE
BGP-25 [Global] Add prettier config files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,30 @@
 # Description
+
 Please include the exact bug/functionality description and a summary of the changes/ related issues. Please also include any other relevant motivation and context:
 Fixes # (bug is related which...)
-Or Implements # (BGP) 
+Or Implements # (BGP)
 
 ## Related PRS (if any):
+
 This frontend PR is related to the #XXX backend PR.
 To test this backend PR you need to checkout the #XXX frontend PR.
 …
 
 ## Main changes explained:
+
 - Delete file A for removing unused components …
 - Update file B for including new pattern …
 - Create file C for introducing new components …
-…
+  …
 
 ## How to test:
+
 1. check into current branch
 2. do `npm install` and `...` to run this PR locally
 3. verify function “A” (feel free to include screenshot here)
 
 ## Screenshots or videos of changes or expecting result:
 
-
-
 ## Note:
+
 Include the information the reviewers need to know.

--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,6 @@ dist
 .pnp.*
 
 # lock files
-*/yarn.lock
-*/package-lock.json
-*/pnpm-lock.yaml
+yarn.lock
+package-lock.json
+pnpm-lock.yaml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+node_modules
+.DS_Store
+dist
+dist-ssr
+*.local
+node_modules/*
+# package.json
+# package-lock.json
+# yarn.lock
+build
+coverage
+dist
+.nvmrc

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "printWidth": 100,
+  "bracketSameLine": false,
+  "quoteProps": "consistent",
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
+  "plugins": ["@trivago/prettier-plugin-sort-imports"]
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,10 +1,9 @@
 {
   "useTabs": false,
   "tabWidth": 2,
-  "printWidth": 100,
   "bracketSameLine": false,
   "quoteProps": "consistent",
-  "importOrderSeparation": true,
   "importOrderSortSpecifiers": true,
+  "importOrderParserPlugins": ["typescript", "decorators-legacy"],
   "plugins": ["@trivago/prettier-plugin-sort-imports"]
 }

--- a/Employee-Client/.eslintrc.cjs
+++ b/Employee-Client/.eslintrc.cjs
@@ -14,6 +14,9 @@ module.exports = {
   plugins: ["react-refresh"],
   rules: {
     "react/jsx-no-target-blank": "off",
-    "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+    "react-refresh/only-export-components": [
+      "warn",
+      { allowConstantExport: true },
+    ],
   },
 };

--- a/Employee-Client/.eslintrc.cjs
+++ b/Employee-Client/.eslintrc.cjs
@@ -6,6 +6,7 @@ module.exports = {
     "plugin:react/recommended",
     "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
+    "prettier",
   ],
   ignorePatterns: ["dist", ".eslintrc.cjs"],
   parserOptions: { ecmaVersion: "latest", sourceType: "module" },
@@ -13,9 +14,6 @@ module.exports = {
   plugins: ["react-refresh"],
   rules: {
     "react/jsx-no-target-blank": "off",
-    "react-refresh/only-export-components": [
-      "warn",
-      { allowConstantExport: true },
-    ],
+    "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
   },
 };

--- a/Employee-Client/index.html
+++ b/Employee-Client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/Employee-Client/package.json
+++ b/Employee-Client/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -21,6 +22,8 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "eslint-config-prettier": "^9.1.0",
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "vite": "^5.1.0"
   }
 }

--- a/Employee-Client/src/main.jsx
+++ b/Employee-Client/src/main.jsx
@@ -1,10 +1,10 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
+import React from "react";
+import ReactDOM from "react-dom/client";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/Employee-Client/vite.config.js
+++ b/Employee-Client/vite.config.js
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/HR-Client/package.json
+++ b/HR-Client/package.json
@@ -6,7 +6,8 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "format": "prettier --write ."
   },
   "private": true,
   "dependencies": {

--- a/HR-Client/src/app/app.component.spec.ts
+++ b/HR-Client/src/app/app.component.spec.ts
@@ -1,6 +1,6 @@
+import { AppComponent } from './app.component';
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -27,7 +27,7 @@ describe('AppComponent', () => {
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('.content span')?.textContent).toContain(
-      'HR-Client app is running!'
+      'HR-Client app is running!',
     );
   });
 });

--- a/HR-Client/src/app/app.module.ts
+++ b/HR-Client/src/app/app.module.ts
@@ -1,8 +1,7 @@
-import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
 
 @NgModule({
   declarations: [AppComponent],

--- a/HR-Client/src/index.html
+++ b/HR-Client/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/HR-Client/src/main.ts
+++ b/HR-Client/src/main.ts
@@ -1,8 +1,7 @@
-import { enableProdMode } from '@angular/core';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+import { enableProdMode } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 if (environment.production) {
   enableProdMode();

--- a/HR-Client/src/polyfills.ts
+++ b/HR-Client/src/polyfills.ts
@@ -45,7 +45,9 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js'; // Included with Angular CLI.
+import 'zone.js';
+
+// Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/HR-Client/src/test.ts
+++ b/HR-Client/src/test.ts
@@ -1,17 +1,16 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
-
-import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
+import 'zone.js/testing';
 
 declare const require: {
   context(
     path: string,
     deep?: boolean,
-    filter?: RegExp
+    filter?: RegExp,
   ): {
     <T>(id: string): T;
     keys(): string[];
@@ -19,10 +18,7 @@ declare const require: {
 };
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);

--- a/Server/.eslintrc.cjs
+++ b/Server/.eslintrc.cjs
@@ -3,7 +3,7 @@ module.exports = {
     es2021: true,
     node: true,
   },
-  extends: "eslint:recommended",
+  extends: ["eslint:recommended", "prettier"],
   overrides: [
     {
       env: {

--- a/Server/app.js
+++ b/Server/app.js
@@ -1,10 +1,10 @@
+import DevRouter from "./routers/DevRouter.js";
 import cookieParser from "cookie-parser";
 import cors from "cors";
 import express from "express";
 import morgan from "morgan";
 import path from "path";
 import process from "process";
-import DevRouter from "./routers/DevRouter.js";
 
 const app = express();
 

--- a/Server/app.js
+++ b/Server/app.js
@@ -1,9 +1,9 @@
-import express from "express";
+import cookieParser from "cookie-parser";
 import cors from "cors";
+import express from "express";
 import morgan from "morgan";
 import path from "path";
 import process from "process";
-import cookieParser from "cookie-parser";
 
 const app = express();
 

--- a/Server/config/seed.js
+++ b/Server/config/seed.js
@@ -1,6 +1,6 @@
+import { Profile, User } from "../models/index.js";
 import argon2 from "argon2";
 import mongoose from "mongoose";
-import { User, Profile } from "../models/index.js";
 
 const MONGO_URL = process.env.MONGO_URL;
 

--- a/Server/index.js
+++ b/Server/index.js
@@ -1,7 +1,6 @@
 import app from "./app.js";
-import process from "process";
-
 import mongoose from "mongoose";
+import process from "process";
 
 mongoose
   .connect(process.env.MONGO_URL)

--- a/Server/models/FacilityReport.model.js
+++ b/Server/models/FacilityReport.model.js
@@ -1,5 +1,5 @@
-import mongoose from "mongoose";
 import constants from "../config/constants.js";
+import mongoose from "mongoose";
 
 const Schema = mongoose.Schema;
 

--- a/Server/models/Profile.model.js
+++ b/Server/models/Profile.model.js
@@ -1,5 +1,5 @@
-import mongoose from "mongoose";
 import constants from "../config/constants.js";
+import mongoose from "mongoose";
 
 const Schema = mongoose.Schema;
 const refType = Schema.Types.ObjectId;

--- a/Server/models/User.model.js
+++ b/Server/models/User.model.js
@@ -1,5 +1,5 @@
-import mongoose from "mongoose";
 import constants from "../config/constants.js";
+import mongoose from "mongoose";
 
 const Schema = mongoose.Schema;
 const refType = Schema.Types.ObjectId;

--- a/Server/models/index.js
+++ b/Server/models/index.js
@@ -1,7 +1,7 @@
-import Document from "./Document.model.js";
-import Housing from "./Housing.model.js";
-import FacilityReport from "./FacilityReport.model.js";
 import Comment from "./Comment.model.js";
+import Document from "./Document.model.js";
+import FacilityReport from "./FacilityReport.model.js";
+import Housing from "./Housing.model.js";
 import Profile from "./Profile.model.js";
 import User from "./User.model.js";
 

--- a/Server/models/index.js
+++ b/Server/models/index.js
@@ -1,5 +1,5 @@
-import User from "./User.model.js";
-import Profile from "./Profile.model.js";
 import Document from "./Document.model.js";
+import Profile from "./Profile.model.js";
+import User from "./User.model.js";
 
 export { User, Profile, Document };

--- a/Server/package.json
+++ b/Server/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "nodemon --env-file .env index.js ",
-    "format": "prettier --write ..",
+    "format": "prettier --write .",
     "seed": "node --env-file .env config/seed.js"
   },
   "dependencies": {

--- a/Server/package.json
+++ b/Server/package.json
@@ -8,7 +8,7 @@
     "seed": "node --env-file .env config/seed.js"
   },
   "dependencies": {
-    "argon2": "^0.31.2",
+    "argon2": "^0.40.1",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/Server/package.json
+++ b/Server/package.json
@@ -3,7 +3,7 @@
   "module": "index.js",
   "type": "module",
   "scripts": {
-    "format": "prettier --write ..",
+    "format": "prettier --write .",
     "dev": "nodemon --env-file .env index.js ",
     "seed": "node --env-file .env config/seed.js"
   },
@@ -18,7 +18,9 @@
     "morgan": "^1.10.0"
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
     "nodemon": "^3.0.3",
     "prettier": "^3.2.5"
   }

--- a/Server/routers/DevRouter.js
+++ b/Server/routers/DevRouter.js
@@ -1,7 +1,6 @@
 // For development purposes only, remove in production
-
-import { Router } from "express";
 import { getOneFile } from "../utils/s3.js";
+import { Router } from "express";
 
 const router = Router();
 

--- a/Server/utils/s3.js
+++ b/Server/utils/s3.js
@@ -1,10 +1,10 @@
+import { bucketName, s3 } from "../config/s3.js";
 import {
   DeleteObjectCommand,
   GetObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
 } from "@aws-sdk/client-s3";
-import { s3, bucketName } from "../config/s3.js";
 
 /**
  * List files in the bgp-zichan S3 bucket.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bf-hr-employee",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0"
+  }
+}


### PR DESCRIPTION
# Description
Added config files for prettier, enabled import sort

## Main changes explained:
- Added `.prettierrc` and `.prettierignore` files for prettier rules configuration
- Enabled import sort with prettier and https://github.com/trivago/prettier-plugin-sort-imports
- Hoisted argon2 version


## How to test:
1. check into current branch
2. install dependencies in the root directory
3. run `format` in Server or Employee-client directory

## Note:
Make sure to install dependencies under the root after pulling these commits
